### PR TITLE
Ignore all inside lib folder except libphonenumber

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,9 +1,7 @@
 /bower_components/
 /node_modules/
-/lib/jasmine/
-/lib/jasmine-jquery/
-/lib/jquery/
-/lib/flag-icon-css/
+/lib/*
+!/lib/libphonenumber 
 /.bower_cache/
 /.sass-cache/
 /.grunt/


### PR DESCRIPTION
After running of the ```grunt bower``` command there is the *region-flags* folder inside the *lib* folder that is not ignored. The *.gitignore* file was updated to ignore all files and folders inside the *lib* folder except  the *libphonenumber* folder.