### PR TITLE
Make mobile popup position fixed

### DIFF
--- a/src/css/intlTelInput.scss
+++ b/src/css/intlTelInput.scss
@@ -291,6 +291,7 @@ $mobilePopupMargin: 30px;
     bottom: $mobilePopupMargin;
     left: $mobilePopupMargin;
     right: $mobilePopupMargin;
+    position: fixed;
   }
   .country-list {
     max-height: 100%;


### PR DESCRIPTION
Before, when the mobile popup was opened from the bottom of a long page it could appear too high up, preventing it from being visible.

Using a fixed position ensures the popup will always be visible in the same place relative to the users viewport, not just the top of the page.

Seems like a quick change, but are there any unexpected things to look out for with this?