### PR TITLE
Remove jquery from dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
   ],
   "license": "MIT",
   "author": "Jack O'Connor (http://jackocnr.com)",
-  "dependencies": {
+  "peerDependencies": {
     "jquery": ">=1.7"
   },
   "devDependencies": {


### PR DESCRIPTION
Fixes some of the comments in jackocnr/intl-tel-input#54

I'm trying to use code like this

```js
require(['jquery', 'intl-tel-input'], function ($) {
   $('.phone').intlTelInput();
});
```

But I get the error

```
TypeError: $(...).intlTelInput is not a function
```

Took me a while to figure out, but it turns out that webpack includes jQuery twice in the bundle.

```js
webpackJsonp([1],{
   2: function(module, exports, __webpack_require__) {
       // jQuery imported by my script
   },
   3: function(module, exports, __webpack_require__) {
      /*
	 * International Telephone Input v9.0.8
	 * https://github.com/jackocnr/intl-tel-input.git
	 * Licensed under the MIT license
	 */
	// wrap in UMD - see https://github.com/umdjs/umd/blob/master/jqueryPluginCommonjs.js
	(function(factory) {
	    if (true) {
	        !(__WEBPACK_AMD_DEFINE_ARRAY__ = [ __webpack_require__(4) ], __WEBPACK_AMD_DEFINE_RESULT__ = function($) {
	            factory($, window, document);
	        }.apply(exports, __WEBPACK_AMD_DEFINE_ARRAY__), __WEBPACK_AMD_DEFINE_RESULT__ !== undefined && (module.exports = __WEBPACK_AMD_DEFINE_RESULT__));
	    } else if (typeof module === "object" && module.exports) {
	        module.exports = factory(require("jquery"), window, document);
	    } else {
	        factory(jQuery, window, document);
	    }
	})(function($, window, document, undefined) {
             // intl-tel-input
       })
   },
   4: function(module, exports, __webpack_require__) {
      // jQuery requireb by intl-tel-input
   }
})
```

Because jQuery is marked as an explicit dependency of `intl-tel-input`, webpack includes both `node_modules/jquery` and `node_modules/intl-tel-input/node_modules/jquery` in the bundle.

I've tried [DedupePlugin](https://webpack.github.io/docs/list-of-plugins.html#dedupeplugin) but that didn't work.

The simplest fix is to set `jquery` as a peer dependency (which is exactly what it is).