### PR TITLE
Force GET type ajax call for Utils script

### DIFF
--- a/src/js/intlTelInput.js.ejs
+++ b/src/js/intlTelInput.js.ejs
@@ -1270,6 +1270,7 @@ $.fn[pluginName].loadUtils = function(path, utilsScriptDeferred) {
 
     // dont use $.getScript as it prevents caching
     $.ajax({
+      type: 'GET',
       url: path,
       complete: function() {
         // tell all instances that the utils request is complete


### PR DESCRIPTION
jQuery's ajax method is pre-loaded with settings from previous calls (in my case a POST request) causing a POST request to the js file which returned a 405 Method Not Allowed. Fix by forcing GET type request to the resource ```

 ``` ```

 ```