### PR TITLE
recommend HTTPS for $.get in geoIpLookup sample

### DIFF
--- a/README.md
+++ b/README.md
@@ -127,10 +127,10 @@ Format the input value (according to the `nationalMode` option) during initialis
 Type: `Function` Default: `null`  
 When setting `initialCountry` to `"auto"`, you must use this option to specify a custom function that looks up the user's location. Also note that when instantiating the plugin, we now return a [deferred object](https://api.jquery.com/category/deferred-object/), so you can use `.done(callback)` to know when initialisation requests like this have completed.
 
-Here is an example using the [ipinfo.io](http://ipinfo.io/) service:  
+Here is an example using the [ipinfo.io](https://ipinfo.io/) service:  
 ```js
 geoIpLookup: function(callback) {
-  $.get("http://ipinfo.io", function() {}, "jsonp").always(function(resp) {
+  $.get("https://ipinfo.io", function() {}, "jsonp").always(function(resp) {
     var countryCode = (resp && resp.country) ? resp.country : "";
     callback(countryCode);
   });


### PR DESCRIPTION
without this fix, this sample code will fail when run from a HTTPS page