### PR TITLE
Prevent numeric strings from overflowing integer parsing

### DIFF
--- a/src/js/utils.js
+++ b/src/js/utils.js
@@ -18,8 +18,12 @@ function formatNumber(number, countryCode, format) {
   try {
     var phoneUtil = i18n.phonenumbers.PhoneNumberUtil.getInstance();
     var numberObj = phoneUtil.parseAndKeepRawInput(number, countryCode);
-    format = (typeof format == "undefined") ? i18n.phonenumbers.PhoneNumberFormat.E164 : format;
-    return phoneUtil.format(numberObj, format);
+    if (phoneUtil.isPossibleNumber(numberObj)) {
+        format = (typeof format == "undefined") ? i18n.phonenumbers.PhoneNumberFormat.E164 : format;
+        return phoneUtil.format(numberObj, format);
+    } else {
+        return number;
+    }
   } catch (e) {
     return number;
   }


### PR DESCRIPTION
In libphonenumber, number parsing involves calling parseInt(). If the number passed for parsing is larger than 2^53-1, it will be parsed into an integer that is different from the original string representation. The result is that when calling "getNumber" on a long numerical string, one may receive a number that is different from the one entered.