### PR TITLE
Update to jQuery 3.3.1

### DIFF
--- a/demo.html
+++ b/demo.html
@@ -16,7 +16,7 @@
   </form>
 
   <!-- Load jQuery from CDN so can run demo immediately -->
-  <script src="https://ajax.googleapis.com/ajax/libs/jquery/1.11.1/jquery.min.js"></script>
+  <script src="https://ajax.googleapis.com/ajax/libs/jquery/3.3.1/jquery.min.js"></script>
   <script src="build/js/intlTelInput.js"></script>
   <script>
     $("#phone").intlTelInput({


### PR DESCRIPTION
jQuery 1.x and 2.x are not supported and have security vulnerabilities.
This plugin does not support IE8 so it's fine to move to jQuery 3. File size is smaller too so loads faster :-)