### PR TITLE
Fix placeholder capping bug

### DIFF
--- a/src/js/intlTelInput.js
+++ b/src/js/intlTelInput.js
@@ -372,7 +372,7 @@ Plugin.prototype = {
   // update hidden input on form submit
   _initHiddenInputListener: function() {
     var that = this;
-    
+
     var form = this.telInput.closest("form");
     if (form.length) {
       form.submit(function() {
@@ -917,7 +917,7 @@ Plugin.prototype = {
       var numberType = intlTelInputUtils.numberType[this.options.placeholderNumberType],
         placeholder = (this.selectedCountryData.iso2) ? intlTelInputUtils.getExampleNumber(this.selectedCountryData.iso2, this.options.nationalMode, numberType) : "";
 
-      placeholder = this._beforeSetNumber(placeholder);
+      placeholder = this._beforeSetNumber(placeholder, true);
 
       if (typeof this.options.customPlaceholder === 'function') {
         placeholder = this.options.customPlaceholder(placeholder, this.selectedCountryData);
@@ -1094,7 +1094,7 @@ Plugin.prototype = {
 
 
   // remove the dial code if separateDialCode is enabled
-  _beforeSetNumber: function(number) {
+  _beforeSetNumber: function(number, isPlaceHolder) {
     if (this.options.separateDialCode) {
       var dialCode = this._getDialCode(number);
       if (dialCode) {
@@ -1110,6 +1110,11 @@ Plugin.prototype = {
         var start = (number[dialCode.length] === " " || number[dialCode.length] === "-") ? dialCode.length + 1 : dialCode.length;
         number = number.substr(start);
       }
+    }
+
+    // Prevent capping placeholders
+    if(isPlaceHolder) {
+      return number;
     }
 
     return this._cap(number);


### PR DESCRIPTION
## Bug: 

![intl-tel-input-placeholder-bug](https://user-images.githubusercontent.com/7111256/35971558-51885bd8-0c83-11e8-8a8d-a38a2acfb926.gif)

### Observed: 

1. User selects U.S. from the dropdown.
2. User then selects U.K. from the dropdown.
3. User then reselects U.S. from dropdown.

It is observed that the U.S. placeholder is being cut off after reselection. 

### Expected:

The placeholders should be displayed as expected no matter which/when a country is selected.

## Thoughts
This bug essentially occurs when the user has selected a country that has a shorter placeholder and then selects one that has a longer one. The longer placeholder is being cut off in a predictable way. 

It appears that this bug originates in `Plugin#_cap` function in `intlTelInput.js`. 

`_updatePlaceholder` calls `_beforeSetNumber` which then calls `_cap`. `_beforeSetNumber` is called in various scenarios, however the problematic one is when it is called from `_updatePlaceholder.` It seems like the method to control input length is, in this case, cutting off the end of longer placeholders (after previously selecting a shorter one). This seems due to the `maxlength` attribute being out of sync. 

It seems like `_cap` could be bypassed when handling placeholders. 