### PR TITLE
Fix for chrome: Change autocomplete to "nope"

### DIFF
--- a/src/js/intlTelInput.js
+++ b/src/js/intlTelInput.js
@@ -212,7 +212,7 @@ Plugin.prototype = {
   // generate all of the markup for the plugin: the selected flag overlay, and the dropdown
   _generateMarkup: function() {
     // prevent autocomplete as there's no safe, cross-browser event we can react to, so it can easily put the plugin in an inconsistent state e.g. the wrong flag selected for the autocompleted number, which on submit could mean the wrong number is saved (esp in nationalMode)
-    this.telInput.attr("autocomplete", "off");
+    this.telInput.attr("autocomplete", "nope");
 
     // containers (mostly for positioning)
     var parentClass = "intl-tel-input";


### PR DESCRIPTION
Set show autocomplete to "nope" (false and no seem to be ignored by chrome)