### PR TITLE
[Feature] Add an option for a custom user-agent string

### DIFF
--- a/README.md
+++ b/README.md
@@ -188,6 +188,10 @@ Allows to translate the countries by its given iso code e.g.:
 { 'de': 'Deutschland' }
 ```
 
+**customUserAgent**
+Type: `String` Default: `null`
+Use a custom user-agent string for testing whether the user device is mobile or not. This will override the default
+user agent string `Android.+Mobile|webOS|iPhone|iPod|BlackBerry|IEMobile|Opera Mini`.
 
 ## Public Methods
 **destroy**  

--- a/README.md
+++ b/README.md
@@ -188,10 +188,9 @@ Allows to translate the countries by its given iso code e.g.:
 { 'de': 'Deutschland' }
 ```
 
-**customUserAgent**
-Type: `String` Default: `null`
-Use a custom user-agent string for testing whether the user device is mobile or not. This will override the default
-user agent string `Android.+Mobile|webOS|iPhone|iPod|BlackBerry|IEMobile|Opera Mini`.
+**customUserAgent**  
+Type: `String` Default: `null`  
+Use a custom user-agent string for testing whether the user device is mobile or not. This will override the default user agent string `Android.+Mobile|webOS|iPhone|iPod|BlackBerry|IEMobile|Opera Mini`.
 
 ## Public Methods
 **destroy**  

--- a/src/js/intlTelInput.js
+++ b/src/js/intlTelInput.js
@@ -36,6 +36,8 @@ var pluginName = "intlTelInput",
     separateDialCode: false,
     // specify the path to the libphonenumber script to enable validation/formatting
     utilsScript: "",
+    // add custom user agent strings for determing whether the device is mobile or not
+    customUserAgents: [],
   },
   keys = {
     UP: 38,
@@ -90,7 +92,12 @@ Plugin.prototype = {
     // we cannot just test screen size as some smartphones/website meta tags will report desktop resolutions
     // Note: for some reason jasmine breaks if you put this in the main Plugin function with the rest of these declarations
     // Note: to target Android Mobiles (and not Tablets), we must find "Android" and "Mobile"
-    this.isMobile = /Android.+Mobile|webOS|iPhone|iPod|BlackBerry|IEMobile|Opera Mini/i.test(navigator.userAgent);
+    var defaultString = 'Android.+Mobile|webOS|iPhone|iPod|BlackBerry|IEMobile|Opera Mini';
+    this.isMobile = new RegExp(
+      this.options.customUserAgents.length > 0 ?
+        this.options.customUserAgents.join('|') :
+        defaultString,
+      'i').test(navigator.userAgent);
 
     if (this.isMobile) {
       // trigger the mobile dropdown css

--- a/src/js/intlTelInput.js
+++ b/src/js/intlTelInput.js
@@ -36,8 +36,8 @@ var pluginName = "intlTelInput",
     separateDialCode: false,
     // specify the path to the libphonenumber script to enable validation/formatting
     utilsScript: "",
-    // add custom user agent strings for determing whether the device is mobile or not
-    customUserAgents: [],
+    // use a custom user-agent string for testing whether the user device is mobile or not
+    customUserAgent: null,
   },
   keys = {
     UP: 38,
@@ -94,8 +94,8 @@ Plugin.prototype = {
     // Note: to target Android Mobiles (and not Tablets), we must find "Android" and "Mobile"
     var defaultString = 'Android.+Mobile|webOS|iPhone|iPod|BlackBerry|IEMobile|Opera Mini';
     this.isMobile = new RegExp(
-      this.options.customUserAgents.length > 0 ?
-        this.options.customUserAgents.join('|') :
+      this.options.customUserAgent !== null ?
+        this.options.customUserAgent :
         defaultString,
       'i').test(navigator.userAgent);
 


### PR DESCRIPTION
Added an option to use a custom user-agent string for testing whether the user device is mobile or not. Setting this option will override the default user-agent string.
This feature was added because the company I work with has a hybrid mobile app with a custom user agent.