### PR TITLE
chore: at least Node.js 8 is required

### DIFF
--- a/package.json
+++ b/package.json
@@ -50,6 +50,9 @@
     "region-flags": "^1.1.0",
     "time-grunt": "^1.4.0"
   },
+  "engines": {
+    "node": ">= 8"
+  },
   "repository": {
     "type": "git",
     "url": "https://github.com/jackocnr/intl-tel-input.git"


### PR DESCRIPTION
This will be a breaking change for users who use intl-tel-input on a platform with Node.js < 8 so we should consider to bump the major version of intl-tel-input.