### PR TITLE
Update intlTelInput.js

### DIFF
--- a/src/js/intlTelInput.js
+++ b/src/js/intlTelInput.js
@@ -191,6 +191,8 @@ class Iti {
 
   // add a country code to this.countryCodes
   _addCountryCode(iso2, dialCode, priority) {
+    if (dialCode.length > this.dialCodeMaxLen)
+      this.dialCodeMaxLen = dialCode.length;
     if (!this.countryCodes.hasOwnProperty(dialCode)) {
       this.countryCodes[dialCode] = [];
     }
@@ -238,6 +240,7 @@ class Iti {
 
   // process the countryCodes map
   _processCountryCodes() {
+    this.dialCodeMaxLen = 0;
     this.countryCodes = {};
     for (let i = 0; i < this.countries.length; i++) {
       const c = this.countries[i];
@@ -1103,7 +1106,7 @@ class Iti {
             dialCode = number.substr(0, i + 1);
           }
           // longest dial code is 4 chars
-          if (numericChars.length === 4) {
+          if (numericChars.length === this.dialCodeMaxLen) {
             break;
           }
         }


### PR DESCRIPTION
auto-generating max dial code length, to protect us if we end up adding even longer ones in the future. Also technically the number could vary between instances, depending on the onlyCountries setting, so it would be great to generate one per instance, during the plugin init code, and store it as an instance variable. 
-- As proposed by the author --