### PR TITLE
Adding CSS to Project With Webpack or Laravel-mix.

### DIFF
--- a/package.json
+++ b/package.json
@@ -63,5 +63,5 @@
     "build:img": "grunt img",
     "watch": "grunt watch"
   }
-  "style": "build/css/intlTelInput.css"
+  "style":"build/css/intlTelInput.css"
 }

--- a/package.json
+++ b/package.json
@@ -63,4 +63,5 @@
     "build:img": "grunt img",
     "watch": "grunt watch"
   }
+  "style": "build/css/intlTelInput.css"
 }

--- a/package.json
+++ b/package.json
@@ -63,5 +63,5 @@
     "build:img": "grunt img",
     "watch": "grunt watch"
   }
-  "style":"build/css/intlTelInput.css"
+  "style": "build/css/intlTelInput.css"
 }


### PR DESCRIPTION
While trying to add intlTelInput.css via webpack or laravel-mix error occurred as image attached 
![test](https://user-images.githubusercontent.com/14879414/83902219-9cb1c980-a779-11ea-8a7e-153c2d554eb0.png)
to avoid this error there should be path to intlTelInput.css in packege.json file as per edited in file
  