### PR TITLE
Add accessibility attributes for selected dial-code node

### DIFF
--- a/src/js/intlTelInput.js
+++ b/src/js/intlTelInput.js
@@ -339,7 +339,12 @@ class Iti {
     this.selectedFlagInner = this._createEl('div', { class: 'iti__flag' }, this.selectedFlag);
 
     if (this.options.separateDialCode) {
-      this.selectedDialCode = this._createEl('div', { class: 'iti__selected-dial-code' }, this.selectedFlag);
+      this.selectedDialCode = this._createEl('div', {
+        class: 'iti__selected-dial-code',
+        role: 'textbox',
+        'aria-label': `iti-${this.id}__selected-dial-code`,
+        title: `iti-${this.id}__dial-code-textbox`
+      }, this.selectedFlag);
     }
 
     if (this.options.allowDropdown) {


### PR DESCRIPTION
According to accessibility requirements "Authors MUST ensure an element with role combobox contains or owns a text input element with role textbox or searchbox", so I add texbox role to country code element + appropriate aria attributes
https://www.w3.org/TR/wai-aria-1.1/#combobox