### PR TITLE
_getFullNumber trim spaces 

### DIFF
--- a/src/js/intlTelInput.js
+++ b/src/js/intlTelInput.js
@@ -1196,7 +1196,7 @@ class Iti {
 
   // get the input val, adding the dial code if separateDialCode is enabled
   _getFullNumber() {
-    const val = this.telInput.value.trim();
+    const val = this.telInput.value.replace(/[^0-9+]+/g, "");
     const { dialCode } = this.selectedCountryData;
     let prefix;
     const numericVal = this._getNumeric(val);


### PR DESCRIPTION
I've fixed the method `_getFullNumber` to replace all special characters (for example if I use the mask plugin) to validate the full number