### PR TITLE
Add the namespace and require to fix the build with the recent Google Closure compiler

### DIFF
--- a/src/js/utils.js
+++ b/src/js/utils.js
@@ -1,6 +1,8 @@
+goog.provide('i18n.phonenumbers.demo');
 // includes
 goog.require('i18n.phonenumbers.PhoneNumberFormat');
 goog.require('i18n.phonenumbers.PhoneNumberUtil');
+goog.require('i18n.phonenumbers.Error');
 
 
 // format the given number to the given format


### PR DESCRIPTION
I tried building the utils with the recent Google Closure compiler following this instructions: https://github.com/jackocnr/intl-tel-input/blob/master/.github/CONTRIBUTING.md#updating-to-a-new-version-of-libphonenumber

I faced the same issue that is mentioned here https://github.com/jackocnr/intl-tel-input/issues/1198

I've managed to fix the issue by updating both code at the libphonenumber side and intl-tel-input side. This PR is the changes required to be able to build `utils.js` with the recent Google Closure compiler version.