### PR TITLE
updating alreadySelected logic to not update the flag when in separateDialCode mode and country already selected

### DIFF
--- a/src/js/intlTelInput.js
+++ b/src/js/intlTelInput.js
@@ -134,8 +134,8 @@ class Iti {
       this.promise = Promise.all([autoCountryPromise, utilsScriptPromise]);
     } else {
       // prevent errors when Promise doesn't exist
-      this.resolveAutoCountryPromise = this.rejectAutoCountryPromise = () => {};
-      this.resolveUtilsScriptPromise = this.rejectUtilsScriptPromise = () => {};
+      this.resolveAutoCountryPromise = this.rejectAutoCountryPromise = () => { };
+      this.resolveUtilsScriptPromise = this.rejectUtilsScriptPromise = () => { };
     }
 
     // in various situations there could be no country selected initially, but we need to be able
@@ -883,8 +883,17 @@ class Iti {
       // longer than the matched dial code because in this case we need to make sure that if
       // there are multiple country matches, that the first one is selected (note: we could
       // just check that here, but it requires the same loop that we already have later)
-      const alreadySelected = (countryCodes.indexOf(this.selectedCountryData.iso2) !== -1)
-        && (numeric.length <= dialCode.length - 1);
+      // If we are in separateDialCode mode, we assume the selected country is the desired country,
+      // unless the number starts with +.
+      const alreadySelected = (() => {
+        if (this.options.separateDialCode) {
+          if (!(originalNumber.length && originalNumber.charAt(0) === '+')) {
+            return (typeof this.selectedCountryData !== 'undefined');
+          }
+        }
+        return (countryCodes.indexOf(this.selectedCountryData.iso2) !== -1)
+          && (numeric.length <= dialCode.length - 1);
+      })();
       const isRegionlessNanpNumber = (selectedDialCode === '1' && this._isRegionlessNanp(numeric));
 
       // only update the flag if:


### PR DESCRIPTION
I believe this is a bug and I'd like to open the discussion with a pull request. 
On the latest version of intl-tel-input, if you change the country from US to another country with the same code (Canada, America Samoa, etc), and start entering a number, the country picker switches back to US. This doesn't feel like a desired behavior. 
In my case, I am using the picker in separateDialCode mode, and nationalMode, and I do not expect users to be entering their country dial code. I expect the dial code to come from the picker. I understand my use case might be unique. Feedback is welcome!