### PR TITLE
separateDialCode should (a) set autoHideDialCode true and (b) be independent of nationalMode

### DIFF
--- a/README.md
+++ b/README.md
@@ -217,7 +217,7 @@ Prevent the user from entering invalid characters. Unfortunately this had to be 
 
 **separateDialCode**  
 Type: `Boolean` Default: `false`  
-Display the country dial code next to the selected flag so it's not part of the typed number. Note that this will disable `nationalMode` because technically we are dealing with international numbers, but with the dial code separated.
+Display the country dial code next to the selected flag so it's not part of the typed number.
 
 <img src="https://raw.github.com/jackocnr/intl-tel-input/master/screenshots/separateDialCode.png" width="257px" height="46px">
 

--- a/src/js/intlTelInput.js
+++ b/src/js/intlTelInput.js
@@ -97,12 +97,8 @@ class Iti {
     // if in nationalMode, disable options relating to dial codes
     if (this.options.nationalMode) this.options.autoHideDialCode = false;
 
-    // if separateDialCode then doesn't make sense to A) insert dial code into input
-    // (autoHideDialCode), and B) display national numbers (because we're displaying the country
-    // dial code next to them)
-    if (this.options.separateDialCode) {
-      this.options.autoHideDialCode = this.options.nationalMode = false;
-    }
+    // if separateDialCode, enable autoHideDialCode (do not insert dial code into input)
+    if (this.options.separateDialCode) this.options.autoHideDialCode = true;
 
     // we cannot just test screen size as some smartphones/website meta tags will report desktop
     // resolutions


### PR DESCRIPTION
This PR makes two changes on the same line re: `separateDialCode` option.

a) If `separateDialCode` is true, it should **not** insert the dial code into the input, i.e. `autoHideDialCode` should be **true**. The pre-existing code comment and the actual logic do not agree, so I've corrected it--I believe the pre-existing logic is a bug.

b) `separateDialCode` should not influence `nationalMode`, and users should be able to set it as per their preference. The default should be that nationalMode is enabled.

The reason is, even if the dial code is shown, users still *think* in terms of national format. As an example, in Japan national has a leading zero, and users expect to enter phone this way even when `+81` is shown:
![image](https://user-images.githubusercontent.com/27655/218908554-cabd3af0-bb57-4b10-8d69-a55d6e2f4feb.png)

If users want a "purist" E.164, they can set `nationalMode` to false. (In the pre-existing logic, there was no way to set it to true!)

(I am using this code in production and users are happy.)