### PR TITLE
Update intlTelInput.scss to fix browser copiability issue (Guidewire Software company)

### DIFF
--- a/src/css/intlTelInput.scss
+++ b/src/css/intlTelInput.scss
@@ -43,8 +43,7 @@ $mobilePopupMargin: 30px !default;
   // paul irish says this is ok
   // http://www.paulirish.com/2012/box-sizing-border-box-ftw/
   * {
-    box-sizing: border-box;
-    -moz-box-sizing: border-box;
+    box-sizing: border-box;   
   }
 
   &__hide {


### PR DESCRIPTION
-moz prefix should be removed because it is outdated and it is course of browser capability issue https://caniuse.com/?search=-moz-box-sizing