### PR TITLE
limit the number of files to be included in the build

### DIFF
--- a/package.json
+++ b/package.json
@@ -61,8 +61,20 @@
     "prettier": "^2.8.7",
     "region-flags": "https://github.com/fonttools/region-flags/archive/refs/tags/1.2.1.tar.gz",
     "sass": "^1.62.0",
-    "time-grunt": "^1.4.0"
+    "time-grunt": "^1.4.0",
+    "prop-types": "^15.8.1",
+    "react": "^18.2.0",
+    "react-dom": "^18.2.0"
   },
+  "files": [
+	  "build/*",
+	  "CHANGELOG.md",
+	  "LICENSE",
+	  "package.json",
+	  "package-lock.json",
+	  "README.md",
+	  "screenshots/*"
+  ],
   "repository": {
     "type": "git",
     "url": "https://github.com/jackocnr/intl-tel-input.git"
@@ -78,10 +90,5 @@
     "watch": "grunt watch",
     "build:react": "node react/build.js && esbuild react/demo/SimpleApp.js --bundle --outfile=react/demo/simple-bundle.js --loader:.js=jsx --format=cjs && esbuild react/demo/ValidationApp.js --bundle --outfile=react/demo/validation-bundle.js --loader:.js=jsx --format=cjs"
   },
-  "style": "build/css/intlTelInput.css",
-  "dependencies": {
-    "prop-types": "^15.8.1",
-    "react": "^18.2.0",
-    "react-dom": "^18.2.0"
-  }
+  "style": "build/css/intlTelInput.css"
 }


### PR DESCRIPTION
This is a proposal to fix #1541.

Changes:

* Move all dependencies to `devDependencies` instead of `dependencies`, so that they are not included when running `npm install intl-tel-input`.
* Only include the build and the documentation inside the npm package.

This dramatically decreases the package size, making it faster to install, and consuming 100x less disk space (1.2MB instead of 122 MB).