### PR TITLE
:bug: Fixes exports

### DIFF
--- a/package.json
+++ b/package.json
@@ -87,5 +87,8 @@
     "build:react": "node react/build.js"
   },
   "style": "build/css/intlTelInput.css",
-  "exports": "./build/js/intlTelInput.js"
+  "exports": {
+    ".": "./build/js/intlTelInput.js",
+    "./*": "./*"
+  }
 }


### PR DESCRIPTION
The exports field only exposed the default file, and not any of the other files many projects depend on like css and utils

This expands it with pattern matched export to allow all files.

This just mimics the old behavior, so I just went with a catch-all