### PR TITLE
fix: Add missing type definition. Allows to autoconfigure typescript compiler

### DIFF
--- a/package.json
+++ b/package.json
@@ -91,5 +91,6 @@
     "./data": "./build/js/data.js",
     "./react": "./react/build/IntlTelInput.js",
     "./*": "./*"
-  }
+  },
+  "types": "./build/js/intlTelInput.d.ts"
 }


### PR DESCRIPTION
Hi,

The `type` entry has been removed from `package.json` in v21.0.6. This should be re-introduced for consumers. Without it, we need to modify tsconfig.json at userland. Which has already been broken by renaming the file between 21.0.5 and 21.0.6

```json
"paths": {
      "intl-tel-input": [
        "node_modules/intl-tel-input/build/js/intlTelInput"
      ]
    },
```
This is needed today, but shouldn't (I do not use React, but angular FWIW)

See one of my comment here :  https://github.com/mpalourdio/intl-tel-input-ng/pull/54#discussion_r1554837350