### PR TITLE
fix: Reorder exports to avoid "Error: Module not found: Error: Default condition should be last one"

### DIFF
--- a/package.json
+++ b/package.json
@@ -95,13 +95,13 @@
   "types": "./build/js/intlTelInput.d.ts",
   "exports": {
     ".": {
-      "default": "./build/js/intlTelInput.js",
-      "types": "./build/js/intlTelInput.d.ts"
+      "types": "./build/js/intlTelInput.d.ts",
+      "default": "./build/js/intlTelInput.js"
     },
     "./data": "./build/js/data.js",
     "./react": {
-      "default": "./react/build/IntlTelInput.js",
-      "types": "./react/build/IntlTelInput.d.ts"
+      "types": "./react/build/IntlTelInput.d.ts",
+      "default": "./react/build/IntlTelInput.js"
     },
     "./*": "./*"
   },


### PR DESCRIPTION
While testing the very latest release, I have been caught with

`Error: Module not found: Error: Default condition should be last one`

Looks like the ordering matters. After moving, them, the error is gone.
This is so intuitive, isn't it ?

https://www.google.com/search?q=Module+not+found%3A+Error%3A+Default+condition+should+be+last+one