### PR TITLE
Fix react `ref` Typescript types

### DIFF
--- a/react/build/IntlTelInput.d.ts
+++ b/react/build/IntlTelInput.d.ts
@@ -989,11 +989,11 @@ declare module "intl-tel-input/react" {
         initOptions?: SomeOptions;
         inputProps?: object;
     };
-    type ItiRef = {
+    export type IntlTelInputRef = {
         getInstance: () => Iti | null;
         getInput: () => HTMLInputElement | null;
     };
-    const IntlTelInput: React.ForwardRefExoticComponent<ItiProps & React.RefAttributes<ItiRef>>;
+    const IntlTelInput: React.ForwardRefExoticComponent<ItiProps & React.RefAttributes<IntlTelInputRef>>;
     export default IntlTelInput;
 }
 declare module "intl-tel-input/utils-compiled" {
@@ -1019,10 +1019,10 @@ declare module "intl-tel-input/reactWithUtils" {
         initOptions?: SomeOptions;
         inputProps?: object;
     };
-    type ItiRef = {
+    export type IntlTelInputRef = {
         getInstance: () => Iti | null;
         getInput: () => HTMLInputElement | null;
     };
-    const IntlTelInput: React.ForwardRefExoticComponent<ItiProps & React.RefAttributes<ItiRef>>;
+    const IntlTelInput: React.ForwardRefExoticComponent<ItiProps & React.RefAttributes<IntlTelInputRef>>;
     export default IntlTelInput;
 }

--- a/react/build/IntlTelInput.d.ts
+++ b/react/build/IntlTelInput.d.ts
@@ -976,7 +976,7 @@ declare module "intl-tel-input" {
 }
 declare module "intl-tel-input/react" {
     import intlTelInput from "intl-tel-input";
-    import { SomeOptions } from "intl-tel-input";
+    import { Iti, SomeOptions } from "intl-tel-input";
     import React from "react";
     export { intlTelInput };
     type ItiProps = {
@@ -989,7 +989,11 @@ declare module "intl-tel-input/react" {
         initOptions?: SomeOptions;
         inputProps?: object;
     };
-    const IntlTelInput: React.ForwardRefExoticComponent<ItiProps & React.RefAttributes<unknown>>;
+    type ItiRef = {
+        getInstance: () => Iti | null;
+        getInput: () => HTMLInputElement | null;
+    };
+    const IntlTelInput: React.ForwardRefExoticComponent<ItiProps & React.RefAttributes<ItiRef>>;
     export default IntlTelInput;
 }
 declare module "intl-tel-input/utils-compiled" {
@@ -1002,7 +1006,7 @@ declare module "intl-tel-input/intlTelInputWithUtils" {
 }
 declare module "intl-tel-input/reactWithUtils" {
     import intlTelInput from "intl-tel-input/intlTelInputWithUtils";
-    import { SomeOptions } from "intl-tel-input";
+    import { Iti, SomeOptions } from "intl-tel-input";
     import React from "react";
     export { intlTelInput };
     type ItiProps = {
@@ -1015,6 +1019,10 @@ declare module "intl-tel-input/reactWithUtils" {
         initOptions?: SomeOptions;
         inputProps?: object;
     };
-    const IntlTelInput: React.ForwardRefExoticComponent<ItiProps & React.RefAttributes<unknown>>;
+    type ItiRef = {
+        getInstance: () => Iti | null;
+        getInput: () => HTMLInputElement | null;
+    };
+    const IntlTelInput: React.ForwardRefExoticComponent<ItiProps & React.RefAttributes<ItiRef>>;
     export default IntlTelInput;
 }

--- a/react/src/intl-tel-input/react.tsx
+++ b/react/src/intl-tel-input/react.tsx
@@ -17,6 +17,11 @@ type ItiProps = {
   inputProps?: object;
 };
 
+type ItiRef = {
+  getInstance: () => Iti | null;
+  getInput: () => HTMLInputElement | null;
+}
+
 const IntlTelInput = forwardRef(function IntlTelInput({
   initialValue = "",
   onChangeNumber = () => {},
@@ -26,7 +31,7 @@ const IntlTelInput = forwardRef(function IntlTelInput({
   usePreciseValidation = false,
   initOptions = {},
   inputProps = {},
-}: ItiProps, ref) {
+}: ItiProps, ref: React.ForwardedRef<ItiRef>) {
   const inputRef = useRef<HTMLInputElement | null>(null);
   const itiRef = useRef<Iti | null>(null);
 

--- a/react/src/intl-tel-input/react.tsx
+++ b/react/src/intl-tel-input/react.tsx
@@ -17,7 +17,7 @@ type ItiProps = {
   inputProps?: object;
 };
 
-type ItiRef = {
+export type IntlTelInputRef = {
   getInstance: () => Iti | null;
   getInput: () => HTMLInputElement | null;
 }
@@ -31,7 +31,7 @@ const IntlTelInput = forwardRef(function IntlTelInput({
   usePreciseValidation = false,
   initOptions = {},
   inputProps = {},
-}: ItiProps, ref: React.ForwardedRef<ItiRef>) {
+}: ItiProps, ref: React.ForwardedRef<IntlTelInputRef>) {
   const inputRef = useRef<HTMLInputElement | null>(null);
   const itiRef = useRef<Iti | null>(null);
 

--- a/react/src/intl-tel-input/reactWithUtils.tsx
+++ b/react/src/intl-tel-input/reactWithUtils.tsx
@@ -18,6 +18,11 @@ type ItiProps = {
   inputProps?: object;
 };
 
+type ItiRef = {
+  getInstance: () => Iti | null;
+  getInput: () => HTMLInputElement | null;
+}
+
 const IntlTelInput = forwardRef(function IntlTelInput({
   initialValue = "",
   onChangeNumber = () => {},
@@ -27,7 +32,7 @@ const IntlTelInput = forwardRef(function IntlTelInput({
   usePreciseValidation = false,
   initOptions = {},
   inputProps = {},
-}: ItiProps, ref) {
+}: ItiProps, ref: React.ForwardedRef<ItiRef>) {
   const inputRef = useRef<HTMLInputElement | null>(null);
   const itiRef = useRef<Iti | null>(null);
 

--- a/react/src/intl-tel-input/reactWithUtils.tsx
+++ b/react/src/intl-tel-input/reactWithUtils.tsx
@@ -18,7 +18,7 @@ type ItiProps = {
   inputProps?: object;
 };
 
-type ItiRef = {
+export type IntlTelInputRef = {
   getInstance: () => Iti | null;
   getInput: () => HTMLInputElement | null;
 }
@@ -32,7 +32,7 @@ const IntlTelInput = forwardRef(function IntlTelInput({
   usePreciseValidation = false,
   initOptions = {},
   inputProps = {},
-}: ItiProps, ref: React.ForwardedRef<ItiRef>) {
+}: ItiProps, ref: React.ForwardedRef<IntlTelInputRef>) {
   const inputRef = useRef<HTMLInputElement | null>(null);
   const itiRef = useRef<Iti | null>(null);
 


### PR DESCRIPTION
Hello 👋 

The current React types don't strongly type the forwarded ref object.  So, when using the component exported from the `intl-tel-input/react` or `intl-tel-input/reactWithUtils` packages with Typescript, you can't actually pass a `ref` to the component.

```tsx
import IntlTelInput from 'intl-tel-input/react'

// ❌ Property 'ref' does not exist on type ...
<IntlTelInput 
  ref={/* ... */}
/>
```

I added a `IntlTelInputRef` type to the `ref` object, and exported it.  The reason the type itself is exported is so that consumers can type their `useRef`, for example:

```tsx
import IntlTelInput from 'intl-tel-input/react'
import type { IntlTelInputRef } from 'intl-tel-input/react'

const ref = useRef<IntlTelInputRef>(null)

// ✅ typechecks 
<IntlTelInput 
  /* ... other props */
  ref={ref}
/>
```

No actual changes to the functionality of the React components or underlying library were made in this PR.  This is solely a Typescript fix.