### PR TITLE
Avoid CSP-incompatible inline style attributes

### DIFF
--- a/src/js/intl-tel-input.ts
+++ b/src/js/intl-tel-input.ts
@@ -573,12 +573,14 @@ export class Iti {
     if (allowDropdown || showFlags || separateDialCode) {
       this.countryContainer = createEl(
         "div",
-        {
-          class: "iti__country-container",
-          style: this.showSelectedCountryOnLeft ? "left: 0" : "right: 0",
-        },
+        { class: "iti__country-container" },
         wrapper,
       );
+      if (this.showSelectedCountryOnLeft) {
+        this.countryContainer.style.left = "0px";
+      } else {
+        this.countryContainer.style.right = "0px";
+      }
 
       //* Selected country (displayed on left of input while allowDropdown is enabled, otherwise to right)
       //* https://www.w3.org/WAI/ARIA/apg/patterns/combobox/examples/combobox-select-only

--- a/tests/core/usingDropdown.test.js
+++ b/tests/core/usingDropdown.test.js
@@ -26,6 +26,33 @@ describe("using dropdown", () => {
   afterEach(() => {
     teardown(iti);
   });
+
+  test("shows selected flag on left by default", async() => {
+    const countryContainer = container.querySelector(".iti__country-container");
+    expect(countryContainer.style.left).toEqual("0px");
+    expect(countryContainer.style.right).toEqual("");
+  });
+
+  describe("with rtl context", () => {
+    let originalDir;
+
+    beforeEach(() => {
+      originalDir = container.ownerDocument.documentElement.dir;
+      container.ownerDocument.documentElement.dir = "rtl";
+      ({ iti, container, input } = initPlugin());
+    });
+        
+    afterEach(() => {
+      teardown(iti);
+      container.ownerDocument.documentElement.dir = originalDir;
+    });
+
+    test("shows selected flag on right", async() => {
+      const countryContainer = container.querySelector(".iti__country-container");
+      expect(countryContainer.style.left).toEqual("");
+      expect(countryContainer.style.right).toEqual("0px");
+    });
+  });
   
   test("clicking the selected flag opens the dropdown", async () => {
     await clickSelectedCountryAsync(container, user);

--- a/tests/core/usingDropdown.test.js
+++ b/tests/core/usingDropdown.test.js
@@ -27,7 +27,7 @@ describe("using dropdown", () => {
     teardown(iti);
   });
 
-  test("shows selected flag on left by default", async() => {
+  test("shows selected flag on left by default", () => {
     const countryContainer = container.querySelector(".iti__country-container");
     expect(countryContainer.style.left).toEqual("0px");
     expect(countryContainer.style.right).toEqual("");
@@ -47,7 +47,7 @@ describe("using dropdown", () => {
       container.ownerDocument.documentElement.dir = originalDir;
     });
 
-    test("shows selected flag on right", async() => {
+    test("shows selected flag on right", () => {
       const countryContainer = container.querySelector(".iti__country-container");
       expect(countryContainer.style.left).toEqual("");
       expect(countryContainer.style.right).toEqual("0px");


### PR DESCRIPTION
**Summary:** Updates country container styling to apply `left` or `right` styles using DOM `style` properties, rather than applying styles through an inline `style` attribute.

**Context:**

When trying to upgrade to the latest version of `intl-tel-input` in our project, I started noticing the following errors in the console:

>Refused to apply inline style because it violates the following Content Security Policy directive: "style-src 'self' 'unsafe-inline' 'nonce-...'". Note that 'unsafe-inline' is ignored if either a hash or nonce value is present in the source list.

Our application enforces a [content security policy (CSP)](https://developer.mozilla.org/en-US/docs/Web/HTTP/CSP), which disallows inline style attributes by default ([see `style-src` `unsafe-inline` reference](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Content-Security-Policy/style-src#unsafe_inline_styles)).

For the purpose of how `intl-tel-input` is applying these styles, it's simple enough to swap the `style` attribute with `style` property assignments.

From the above MDN resource:

>styles properties that are set directly on the element's [style](https://developer.mozilla.org/en-US/docs/Web/API/HTMLElement/style) property will not be blocked, allowing users to safely manipulate styles via JavaScript:

This also appears to be the only inline style attribute applied in the project, and there are several other instances of direct style property assignment ([example](https://github.com/jackocnr/intl-tel-input/blob/684e0ccf5061875395bf6aea9e73df3c75534539/src/js/intl-tel-input.ts#L1079)).

Included are regression specs which pass before and after the change, included to increase confidence in changes.