### PR TITLE
feat: Finalize Vue demos and improve Vue component

### DIFF
--- a/vue/README.md
+++ b/vue/README.md
@@ -5,9 +5,12 @@ A Vue component wrapper for the [intl-tel-input](https://github.com/jackocnr/int
 - [Demo](#demo)
 - [Getting Started](#getting-started)
 - [Props](#props)
+- [Events](#events)
+- [Accessing Instance Methods](#accessing-instance-methods)
+- [Accessing Static Methods](#accessing-static-methods)
 
 ## Demo
-Try it for yourself by downloading the project and running `npm install` and then `npm run vue:demo` and then copy the given URL into your browser. NOTE: the component is rendering the plugin correctly, but we still need help hooking up the [validation functionality](https://github.com/jackocnr/intl-tel-input/blob/master/vue/demo/validation/App.vue)!
+Try it for yourself by downloading the project and running `npm install` and then `npm run vue:demo` and then copy the given URL into your browser.
 
 ## Getting Started
 ```vue
@@ -25,15 +28,56 @@ Try it for yourself by downloading the project and running `npm install` and the
 </template>
 ```
 
-See the [Validation demo](https://github.com/jackocnr/intl-tel-input/blob/master/vue/demo/validation/App.vue) for a more fleshed-out example of how to handle validation [COMING SOON].
+See the [Validation demo](https://github.com/jackocnr/intl-tel-input/blob/master/vue/demo/validation/App.vue) for a more fleshed-out example of how to handle validation. Make sure to change the path in the `package.json` script to the correct demo if you're running it locally e.g.:
+
+```
+"vue:demo": "vite --config vue/demo/[demo variant]/vite.config.js"
+```
 
 A note on the utils script (~260KB): if you're lazy loading the IntlTelInput chunk (and so less worried about filesize) then you can just import IntlTelInput from `"intl-tel-input/vueWithUtils"`, to include the utils script. Alternatively, if you use the main `"intl-tel-input/vue"` import, then you should couple this with the `utilsScript` initialisation option - you will need to host the [utils.js](https://github.com/jackocnr/intl-tel-input/blob/master/build/js/utils.js) file, and then set the `utilsScript` option to that URL, or alternatively just point it to a CDN hosted version e.g. `"https://cdn.jsdelivr.net/npm/intl-tel-input@24.3.7/build/js/utils.js"`.
 
 ## Props
 Here's a list of all of the current props you can pass to the IntlTelInput Vue component.
 
-**options**  
-Type: `Object`  
+**disabled**
+Type: `Boolean`, Default: `false`
+Sets the disabled attribute of both the telephone input and selected country button. *Note: we recommend using this instead of `inputProps.disabled`.*
+
+**inputProps**
+Type: `Object`
+The props to pass to the input element e.g. `id`, `class`, `placeholder`, `required`, `onBlur` etc. *Note: we recommend using the separate `disabled` prop instead of `inputProps.disabled`.*
+
+**options**
+Type: `Object`
 An object containing the [initialisation options](https://github.com/jackocnr/intl-tel-input?tab=readme-ov-file#initialisation-options) to pass to the plugin. You can use these exactly the same way as with the main JavaScript plugin.
 
-[MORE COMING SOON]
+**value**
+Type: `String`
+The initial value to put in the input. This will get auto-formatted on init (according to `formatOnDisplay` initialisation option). IntlTelInput is an uncontrolled input, and so will ignore any changes to this value.
+
+## Events
+Here's a list of all of the current events you can listen to on the IntlTelInput Vue component.
+
+**changeCountry**
+Type: `Function`
+A handler to be called when the selected country changes. It will be passed the new country iso2 code e.g. "gb" for UK.
+
+**changeErrorCode**
+Type: `Function`
+A handler to be called when the number validation error changes. It will be passed the new error code (or `null`).
+
+**changeNumber**
+Type: `Function`
+A handler to be called when the number changes. It will be passed the new number.
+
+**changeValidity**
+Type: `Function`
+A handler to be called when the number validity changes e.g. to true/false. It will be passed the new isValid boolean.
+
+## Accessing Instance Methods
+
+You can access all of the plugin's [instance methods](https://github.com/jackocnr/intl-tel-input/blob/master/README.md#instance-methods) (`setNumber`, `setCountry`, `setPlaceholderNumberType` etc) by passing a ref into the IntlTelInput component (using the `ref` prop), and then calling `ref.intlTelInput.instance` e.g. `ref.intlTelInput.instance.setNumber(...);`. See the [Set Number demo](https://github.com/jackocnr/intl-tel-input/blob/master/vue/demo/set-number/App.vue) for a full example. You can also access the input DOM element in a similar way: `ref.intlTelInput.input`.
+
+## Accessing Static Methods
+
+You can access all of the plugin's [static methods](https://github.com/jackocnr/intl-tel-input/blob/master/README.md#static-methods) by importing `intlTelInput` from the same file as the Vue component e.g. `import { intlTelInput } from "intl-tel-input/vue"` (note the lower case "i" in "intlTelInput"). You can then use this as you would with the main plugin e.g. `intlTelInput.getCountryData()` or `intlTelInput.utils.numberType` etc.

--- a/vue/demo/set-number/App.vue
+++ b/vue/demo/set-number/App.vue
@@ -15,6 +15,12 @@ const number = ref(null);
 const errorCode = ref(null);
 const notice = ref(null);
 
+const intlTelInputRef = ref(null);
+
+const handleSetNumber = () => {
+  intlTelInputRef.value?.instance?.setNumber("+14155552671");
+};
+
 const handleSubmit = () => {
   if (isValid.value) {
     notice.value = `Valid number: ${number.value}`;
@@ -28,6 +34,7 @@ const handleSubmit = () => {
 <template>
   <form>
     <IntlTelInput
+      ref="intlTelInputRef"
       @changeNumber="number = $event"
       @changeValidity="isValid = $event"
       @changeErrorCode="errorCode = $event"
@@ -35,6 +42,9 @@ const handleSubmit = () => {
         initialCountry: 'us',
       }"
     />
+    <button class="button" type="button" @click="handleSetNumber">
+      Set Number
+    </button>
     <button class="button" type="button" @click="handleSubmit">Validate</button>
     <div v-if="notice" class="notice">{{ notice }}</div>
   </form>

--- a/vue/demo/set-number/index.html
+++ b/vue/demo/set-number/index.html
@@ -1,0 +1,18 @@
+<!DOCTYPE html>
+<html lang="en">
+
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <title>Vue App - Set Number Demo</title>
+</head>
+
+<body>
+  <h1>Vue App - Set Number Demo</h1>
+  <p>A simple Vue app, using the IntlTelInput component to handle phone number entry, calling setNumber and validation.</p>
+  <p>Click "Set Number" then click "Validate" to check that the Vue internals have updated correctly.</p>
+  <div id="app"></div>
+  <script type="module" src="./main.js"></script>
+</body>
+
+</html>

--- a/vue/demo/set-number/main.js
+++ b/vue/demo/set-number/main.js
@@ -1,0 +1,6 @@
+import { createApp } from "vue";
+import App from "./App.vue";
+import "../../../build/css/intlTelInput.css";
+import "../../../build/css/demo.css";
+
+createApp(App).mount("#app");

--- a/vue/demo/set-number/vite.config.js
+++ b/vue/demo/set-number/vite.config.js
@@ -1,0 +1,11 @@
+import { defineConfig } from "vite";
+import vue from "@vitejs/plugin-vue";
+import { version } from "../../../package.json";
+
+export default defineConfig({
+  root: "vue/demo/set-number",
+  define: {
+    "process.env.VERSION": `"${version}"`,
+  },
+  plugins: [vue()],
+});

--- a/vue/demo/toggle-disabled/App.vue
+++ b/vue/demo/toggle-disabled/App.vue
@@ -1,0 +1,17 @@
+<script setup>
+import { ref } from "vue";
+import IntlTelInput from "../../src/intl-tel-input/IntlTelInputWithUtils.vue";
+
+const isDisabled = ref(true);
+
+const toggleDisabled = () => {
+  isDisabled.value = !isDisabled.value;
+};
+</script>
+
+<template>
+  <form>
+    <IntlTelInput :disabled="isDisabled" />
+    <button class="button" type="button" @click="toggleDisabled">Toggle</button>
+  </form>
+</template>

--- a/vue/demo/toggle-disabled/index.html
+++ b/vue/demo/toggle-disabled/index.html
@@ -1,0 +1,18 @@
+<!DOCTYPE html>
+<html lang="en">
+
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <title>Vue App - Toggle disabled prop Demo</title>
+</head>
+
+<body>
+  <h1>Vue App - Toggle disabled prop Demo</h1>
+  <p>A simple Vue app, using the IntlTelInput component to show it can be disabled and enabled.</p>
+  <p>Click the button to enable/disable component</p>
+  <div id="app"></div>
+  <script type="module" src="./main.js"></script>
+</body>
+
+</html>

--- a/vue/demo/toggle-disabled/main.js
+++ b/vue/demo/toggle-disabled/main.js
@@ -1,0 +1,6 @@
+import { createApp } from "vue";
+import App from "./App.vue";
+import "../../../build/css/intlTelInput.css";
+import "../../../build/css/demo.css";
+
+createApp(App).mount("#app");

--- a/vue/demo/toggle-disabled/vite.config.js
+++ b/vue/demo/toggle-disabled/vite.config.js
@@ -1,0 +1,11 @@
+import { defineConfig } from "vite";
+import vue from "@vitejs/plugin-vue";
+import { version } from "../../../package.json";
+
+export default defineConfig({
+  root: "vue/demo/toggle-disabled",
+  define: {
+    "process.env.VERSION": `"${version}"`,
+  },
+  plugins: [vue()],
+});

--- a/vue/src/intl-tel-input/IntlTelInput.vue
+++ b/vue/src/intl-tel-input/IntlTelInput.vue
@@ -1,27 +1,40 @@
 <script setup>
 import intlTelInput from "../intl-tel-input";
-import { onMounted, onUnmounted, ref, watch } from 'vue';
+import { onMounted, onUnmounted, ref, watch } from "vue";
 
 const model = defineModel({
   type: String,
-  default: '',
+  default: "",
 });
 
 const props = defineProps({
+  disabled: {
+    type: Boolean,
+    default: false,
+  },
+
+  inputProps: {
+    type: Object,
+    default: () => ({}),
+  },
+
   options: {
     type: Object,
     default: () => ({}),
   },
+
   value: {
     type: String,
-    default: '',
-  },
-  disabled: {
-    type: Boolean,
+    default: "",
   },
 });
 
-const emit = defineEmits(['changeNumber', 'changeCountry', 'changeValidity', 'changeErrorCode']);
+const emit = defineEmits([
+  "changeNumber",
+  "changeCountry",
+  "changeValidity",
+  "changeErrorCode",
+]);
 
 const input = ref();
 const instance = ref();
@@ -29,7 +42,9 @@ const wasPreviouslyValid = ref(false);
 
 const isValid = () => {
   if (instance.value) {
-    return props.options.strictMode ? instance.value.isValidNumberPrecise() : instance.value.isValidNumber();
+    return props.options.strictMode
+      ? instance.value.isValidNumberPrecise()
+      : instance.value.isValidNumber();
   }
 
   return null;
@@ -41,18 +56,21 @@ const updateValidity = () => {
   if (wasPreviouslyValid.value !== isCurrentlyValid) {
     wasPreviouslyValid.value = isCurrentlyValid;
 
-    emit('changeValidity', !!isCurrentlyValid);
-    emit('changeErrorCode', isCurrentlyValid ? null : instance.value.getValidationError());
+    emit("changeValidity", !!isCurrentlyValid);
+    emit(
+      "changeErrorCode",
+      isCurrentlyValid ? null : instance.value.getValidationError()
+    );
   }
 };
 
 const updateValue = () => {
-  emit('changeNumber', instance.value?.getNumber() ?? '');
+  emit("changeNumber", instance.value?.getNumber() ?? "");
   updateValidity();
 };
 
 const updateCountry = () => {
-  emit('changeCountry', instance.value?.getSelectedCountryData().iso2 ?? '');
+  emit("changeCountry", instance.value?.getSelectedCountryData().iso2 ?? "");
   updateValue();
   updateValidity();
 };
@@ -73,7 +91,7 @@ onMounted(() => {
 
 watch(
   () => props.disabled,
-  newValue => instance.value?.setDisabled(newValue)
+  (newValue) => instance.value?.setDisabled(newValue)
 );
 
 onUnmounted(() => instance.value?.destroy());
@@ -82,5 +100,12 @@ defineExpose({ instance, input });
 </script>
 
 <template>
-  <input ref="input" v-model="model" type="tel" @countrychange="updateCountry" @input="updateValue" />
+  <input
+    ref="input"
+    v-model="model"
+    type="tel"
+    @countrychange="updateCountry"
+    @input="updateValue"
+    v-bind="inputProps"
+  />
 </template>

--- a/vue/src/intl-tel-input/IntlTelInputWithUtils.vue
+++ b/vue/src/intl-tel-input/IntlTelInputWithUtils.vue
@@ -1,28 +1,41 @@
 <!-- THIS FILE IS AUTO-GENERATED. DO NOT EDIT. -->
 <script setup>
 import intlTelInput from "./intlTelInputWithUtils";
-import { onMounted, onUnmounted, ref, watch } from 'vue';
+import { onMounted, onUnmounted, ref, watch } from "vue";
 
 const model = defineModel({
   type: String,
-  default: '',
+  default: "",
 });
 
 const props = defineProps({
+  disabled: {
+    type: Boolean,
+    default: false,
+  },
+
+  inputProps: {
+    type: Object,
+    default: () => ({}),
+  },
+
   options: {
     type: Object,
     default: () => ({}),
   },
+
   value: {
     type: String,
-    default: '',
-  },
-  disabled: {
-    type: Boolean,
+    default: "",
   },
 });
 
-const emit = defineEmits(['changeNumber', 'changeCountry', 'changeValidity', 'changeErrorCode']);
+const emit = defineEmits([
+  "changeNumber",
+  "changeCountry",
+  "changeValidity",
+  "changeErrorCode",
+]);
 
 const input = ref();
 const instance = ref();
@@ -30,7 +43,9 @@ const wasPreviouslyValid = ref(false);
 
 const isValid = () => {
   if (instance.value) {
-    return props.options.strictMode ? instance.value.isValidNumberPrecise() : instance.value.isValidNumber();
+    return props.options.strictMode
+      ? instance.value.isValidNumberPrecise()
+      : instance.value.isValidNumber();
   }
 
   return null;
@@ -42,18 +57,21 @@ const updateValidity = () => {
   if (wasPreviouslyValid.value !== isCurrentlyValid) {
     wasPreviouslyValid.value = isCurrentlyValid;
 
-    emit('changeValidity', !!isCurrentlyValid);
-    emit('changeErrorCode', isCurrentlyValid ? null : instance.value.getValidationError());
+    emit("changeValidity", !!isCurrentlyValid);
+    emit(
+      "changeErrorCode",
+      isCurrentlyValid ? null : instance.value.getValidationError()
+    );
   }
 };
 
 const updateValue = () => {
-  emit('changeNumber', instance.value?.getNumber() ?? '');
+  emit("changeNumber", instance.value?.getNumber() ?? "");
   updateValidity();
 };
 
 const updateCountry = () => {
-  emit('changeCountry', instance.value?.getSelectedCountryData().iso2 ?? '');
+  emit("changeCountry", instance.value?.getSelectedCountryData().iso2 ?? "");
   updateValue();
   updateValidity();
 };
@@ -74,7 +92,7 @@ onMounted(() => {
 
 watch(
   () => props.disabled,
-  newValue => instance.value?.setDisabled(newValue)
+  (newValue) => instance.value?.setDisabled(newValue)
 );
 
 onUnmounted(() => instance.value?.destroy());
@@ -83,5 +101,12 @@ defineExpose({ instance, input });
 </script>
 
 <template>
-  <input ref="input" v-model="model" type="tel" @countrychange="updateCountry" @input="updateValue" />
+  <input
+    ref="input"
+    v-model="model"
+    type="tel"
+    @countrychange="updateCountry"
+    @input="updateValue"
+    v-bind="inputProps"
+  />
 </template>


### PR DESCRIPTION
This PR improves the Vue component by fixing an issue in the validation demo and adding new demos for key features. It also introduces a new prop, `inputProps`, to allow for more flexible input customization. Additionally, the Vue component code has been formatted with Prettier, and the README has been updated accordingly.

### Changes
- Fix incomplete Vue validation demo
- Add new Vue demos for `set-number` and `toggle-disabled`
- Add `inputProps` prop to Vue component to allow setting input attributes
- Format Vue component code using Prettier
- Update Vue component README