### PR TITLE
Update countries.ts

### DIFF
--- a/src/js/intl-tel-input/i18n/en/countries.ts
+++ b/src/js/intl-tel-input/i18n/en/countries.ts
@@ -220,7 +220,7 @@ const countryTranslations: I18n = {
   tm: "Turkmenistan",
   tn: "Tunisia",
   to: "Tonga",
-  tr: "Turkey",
+  tr: "Turkiye",
   tt: "Trinidad & Tobago",
   tv: "Tuvalu",
   tw: "Taiwan",


### PR DESCRIPTION
The Republic of Türkiye changed its official name from The Republic of Turkey on 26 May 2022 in a request submitted to the Secretary-General by the country's Minister of Foreign Affairs.

https://www.un.org/en/about-us/member-states/turkiye