### PR TITLE
Fix Danish translation in interface.js

### DIFF
--- a/build/js/i18n/da/interface.js
+++ b/build/js/i18n/da/interface.js
@@ -2,7 +2,7 @@ const interfaceTranslations = {
   selectedCountryAriaLabel: "Valgt land",
   noCountrySelected: "Intet land er valgt",
   countryListAriaLabel: "Liste over lande",
-  searchPlaceholder: "Søge",
+  searchPlaceholder: "Søg",
   zeroSearchResults: "Ingen resultater fundet",
   oneSearchResult: "1 resultat fundet",
   multipleSearchResults: "${count} resultater fundet",


### PR DESCRIPTION
Updated Danish localisation.
The word "Search" in this context is usually written in imperative mood, which in Danish is just "Søg" instead of "Søge" which is the infinitive form.