### PR TITLE
Fix korean translation

### DIFF
--- a/src/js/intl-tel-input/i18n/ko/interface.ts
+++ b/src/js/intl-tel-input/i18n/ko/interface.ts
@@ -5,13 +5,13 @@ const interfaceTranslations: I18n = {
   selectedCountryAriaLabel: "선택한 국가",
   noCountrySelected: "선택한 국가가 없습니다.",
   countryListAriaLabel: "국가 목록",
-  searchPlaceholder: "찾다",
+  searchPlaceholder: "검색",
   zeroSearchResults: "검색 결과가 없습니다",
-  oneSearchResult: "검색된 결과 1개",
+  oneSearchResult: "1개의 결과를 찾았습니다.",
   multipleSearchResults: "${count}개의 결과를 찾았습니다.",
-  
+
   // additional countries (not supported by country-list library)
-  ac: "승천섬",
+  ac: "어센션섬",
   xk: "코소보",
 };
 


### PR DESCRIPTION
- fixed awkward expression due to Google Translate
- unified the wording for one search result and several search results
- fixed the Ascension Island that was misinterpreted as 'Seungcheon Island(승천섬)'