### PR TITLE
Add type for inputProps

### DIFF
--- a/react/src/intl-tel-input/react.tsx
+++ b/react/src/intl-tel-input/react.tsx
@@ -6,7 +6,7 @@ import React, { useRef, useEffect, forwardRef, useImperativeHandle, useCallback 
 // make this available as a named export, so react users can access globals like intlTelInput.utils
 export { intlTelInput };
 
-type InputProps = Omit<React.ComponentPropsWithoutRef<"input">, "type" | "onInput" | "defaultValue">;
+type InputProps = Omit<React.ComponentPropsWithoutRef<"input">, "onInput">;
 
 type ItiProps = {
   initialValue?: string;

--- a/react/src/intl-tel-input/react.tsx
+++ b/react/src/intl-tel-input/react.tsx
@@ -6,6 +6,8 @@ import React, { useRef, useEffect, forwardRef, useImperativeHandle, useCallback 
 // make this available as a named export, so react users can access globals like intlTelInput.utils
 export { intlTelInput };
 
+type InputProps = Omit<React.ComponentPropsWithoutRef<"input">, "type" | "onInput" | "defaultValue">;
+
 type ItiProps = {
   initialValue?: string;
   onChangeNumber?: (number: string) => void;
@@ -14,7 +16,7 @@ type ItiProps = {
   onChangeErrorCode?: (errorCode: number | null) => void;
   usePreciseValidation?: boolean;
   initOptions?: SomeOptions;
-  inputProps?: object;
+  inputProps?: InputProps;
   disabled?: boolean | undefined;
 };
 


### PR DESCRIPTION
This PR narrows the type of `ItiProps.inputProps`from `object`, which accepts anything, to only the properties supported by the underlying `<input>` component, excluding "ref" and "onInput" which will break the component if set.