### PR TITLE
Fix changeValidity event when there is an initial value

### DIFF
--- a/vue/src/intl-tel-input/IntlTelInput.vue
+++ b/vue/src/intl-tel-input/IntlTelInput.vue
@@ -86,6 +86,7 @@ onMounted(() => {
     if (props.disabled) {
       instance.value.setDisabled(props.disabled);
     }
+    wasPreviouslyValid.value = isValid();
   }
 });
 


### PR DESCRIPTION
I am having trouble working with the `changeValidity` event. I would like to set the initial value when the number is empty to **true** and when not empty it should set `wasPreviouslyValid` to `isValid()`, see my change in this PR... 

Maybe @carlssonemil can take a look?