### PR TITLE
Use placeholder constants to avoid magic strings

### DIFF
--- a/src/js/intl-tel-input.ts
+++ b/src/js/intl-tel-input.ts
@@ -43,6 +43,7 @@ import {
   INPUT_TYPES,
   DIAL,
   US,
+  PLACEHOLDER_MODES,
 } from "./modules/constants";
 
 //* Populate the country names in the default language - useful if you want to use static getCountryData to populate another country dropdown etc.
@@ -1206,8 +1207,8 @@ export class Iti {
       customPlaceholder,
     } = this.options;
     const shouldSetPlaceholder =
-      autoPlaceholder === "aggressive" ||
-      (!this.ui.hadInitialPlaceholder && autoPlaceholder === "polite");
+      autoPlaceholder === PLACEHOLDER_MODES.AGGRESSIVE ||
+      (!this.ui.hadInitialPlaceholder && autoPlaceholder === PLACEHOLDER_MODES.POLITE);
 
     if (intlTelInput.utils && shouldSetPlaceholder) {
       const numberType = intlTelInput.utils.numberType[placeholderNumberType];


### PR DESCRIPTION
Seems like a natural follow-up to https://github.com/jackocnr/intl-tel-input/commit/8d9e093bd2d5f2c8240b27ca8ad7e1da8e873abd and based on the comment at the top of `constants.ts`:

https://github.com/jackocnr/intl-tel-input/blob/efb4e84f962af5ac91863d4231f3371d0bac99aa/src/js/modules/constants.ts#L1-L2

Tested locally and all suites pass :heavy_check_mark: 