### PR TITLE
Expose no-assets build in exports

### DIFF
--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -36,6 +36,10 @@
       "types": "./dist/css/styles.d.ts",
       "default": "./dist/css/intlTelInput.css"
     },
+    "./styles-no-assets": {
+      "types": "./dist/css/styles.d.ts",
+      "default": "./dist/css/intlTelInput-no-assets.css"
+    },
     "./*": "./*"
   },
   "typesVersions": {


### PR DESCRIPTION
There's a no-assets build in `dist/css/intlTelInput-no-assets.css` but it's not exposed via the `exports` field so bundlers won't import it, this just adds a new export field for it 